### PR TITLE
[조형민] 페이지 컨테이너, 타이틀 컴포넌트, 마이갤러리 페이지 등 Feature/21

### DIFF
--- a/api/cards/cards.api.js
+++ b/api/cards/cards.api.js
@@ -1,0 +1,18 @@
+const { client, errorHandler } = require('../client');
+
+const getMyCardsOfGallery = async () => {
+  try {
+    const url = '/cards/me/gallery';
+    const response = await client.get(url);
+
+    return response.data;
+  } catch (error) {
+    errorHandler(error);
+  }
+};
+
+const cardsApi = {
+  getMyCardsOfGallery,
+};
+
+export default cardsApi;

--- a/app/(providers)/(root)/my-cards/gallery/page.jsx
+++ b/app/(providers)/(root)/my-cards/gallery/page.jsx
@@ -1,27 +1,16 @@
-import cardImage1 from '@/assets/images/card-image1.png';
-import Card from '@/components/organism/Card';
+import cardsApi from '@/api/cards/cards.api';
+import PageContainer from '@/components/atoms/PageContainer';
+import CardList from '@/components/organisms/CardList';
+import MyGalleryHeader from '@/components/organisms/MyGalleryHeader';
 
-const card = {
-  seller: '미쓰손',
-  name: '우리집 앞마당 우리집 앞마당 우리집 앞마당',
-  price: 4,
-  exchangePrice: 3,
-  salesEditionCount: 2,
-  totalEditionCount: 5,
-  grade: 'COMMON',
-  genre: '풍경',
-  imgUrl: cardImage1,
-  description:
-    '우리집 앞마당 포토카드입니다. 우리집 앞마당 포토카드입니다. 우리집 앞마당 포토카드입니다.',
-  proposalContent:
-    '스페인 여행 사진도 좋은데..우리집 앞마당 포토카드와 교환하고 싶습니다!',
-};
-
-function MyCardsGalleryPage() {
+async function MyCardsGalleryPage() {
+  const cards = await cardsApi.getMyCardsOfGallery();
   return (
-    <div>
-      <Card card={card} intent="sales" />
-    </div>
+    <PageContainer>
+      {/* client 컴포넌트 */}
+      <MyGalleryHeader />
+      <CardList cards={cards} />
+    </PageContainer>
   );
 }
 

--- a/app/(providers)/(root)/my-cards/gallery/page.jsx
+++ b/app/(providers)/(root)/my-cards/gallery/page.jsx
@@ -6,7 +6,7 @@ const card = {
   name: '우리집 앞마당 우리집 앞마당 우리집 앞마당',
   price: 4,
   exchangePrice: 3,
-  salesEditionCount: 0,
+  salesEditionCount: 2,
   totalEditionCount: 5,
   grade: 'COMMON',
   genre: '풍경',
@@ -20,7 +20,7 @@ const card = {
 function MyCardsGalleryPage() {
   return (
     <div>
-      <Card card={card} intent="exchange" />
+      <Card card={card} intent="sales" />
     </div>
   );
 }

--- a/app/(providers)/(root)/page.js
+++ b/app/(providers)/(root)/page.js
@@ -1,11 +1,15 @@
+import Title from '@/components/molecules/Title';
+
+const { default: PageContainer } = require('@/components/atoms/PageContainer');
+
 function HomePage() {
-  return <div>HomePage</div>;
+  return (
+    <PageContainer>
+      <Title intent="xl" onClick={() => {}} className="sm:hidden">
+        마켓플레이스
+      </Title>
+    </PageContainer>
+  );
 }
 
 export default HomePage;
-
-// function HomePage() {
-//   return <div>HomePage</div>;
-// }
-
-// export default HomePage;

--- a/app/(providers)/(root)/page.js
+++ b/app/(providers)/(root)/page.js
@@ -1,13 +1,16 @@
-import Title from '@/components/molecules/Title';
+import cardsApi from '@/api/cards/cards.api';
+import PageContainer from '@/components/atoms/PageContainer';
+import CardList from '@/components/organisms/CardList';
+import MarketPlaceHeader from '@/components/organisms/MarketPlaceHeader';
 
-const { default: PageContainer } = require('@/components/atoms/PageContainer');
+async function HomePage() {
+  const cards = await cardsApi.getMyCardsOfGallery();
 
-function HomePage() {
   return (
     <PageContainer>
-      <Title intent="xl" onClick={() => {}} className="sm:hidden">
-        마켓플레이스
-      </Title>
+      {/* client 컴포넌트 */}
+      <MarketPlaceHeader />
+      <CardList cards={cards} />
     </PageContainer>
   );
 }

--- a/assets/data/mock.js
+++ b/assets/data/mock.js
@@ -1,0 +1,58 @@
+import cardImage1 from '@/assets/images/card-image1.png';
+import cardImage2 from '@/assets/images/card-image2.png';
+import cardImage3 from '@/assets/images/card-image3.png';
+
+const card1 = {
+  seller: '미쓰손',
+  name: '우리집 앞마당 우리집 앞마당 우리집 앞마당',
+  price: 4,
+  exchangePrice: 3,
+  salesEditionCount: 2,
+  totalEditionCount: 5,
+  grade: 'COMMON',
+  genre: '풍경',
+  imgUrl: cardImage1,
+  description:
+    '우리집 앞마당 포토카드입니다. 우리집 앞마당 포토카드입니다. 우리집 앞마당 포토카드입니다.',
+  proposalContent:
+    '스페인 여행 사진도 좋은데..우리집 앞마당 포토카드와 교환하고 싶습니다!',
+};
+const card2 = {
+  seller: '랍스타',
+  name: 'How Far I"ll Go',
+  price: 7,
+  exchangePrice: 4,
+  salesEditionCount: 1,
+  totalEditionCount: 3,
+  grade: 'RARE',
+  genre: '풍경',
+  imgUrl: cardImage2,
+  description: '하와이 스타일 카드입니다. 야자수가 멋드러집니다.',
+  proposalContent:
+    '푸릇푸릇한 여름 풍경, 눈 많이 내린 겨울 풍경 사진에 관심이 많습니다.',
+};
+const card3 = {
+  seller: '프로여행러',
+  name: '스페인 여행',
+  price: 10,
+  exchangePrice: 0,
+  salesEditionCount: 1,
+  totalEditionCount: 1,
+  grade: 'SUPER RARE',
+  genre: '여행',
+  imgUrl: cardImage3,
+  description:
+    '단 1개밖에 발행되지 않은 희귀한 카드입니다. 스페인 국왕의 사돈의 팔촌이 발행한 카드입니다.',
+  proposalContent: '제 카드로 가능할까요?',
+};
+
+const cards = [card1, card2, card3];
+
+const mockData = {
+  card1,
+  card2,
+  card3,
+  cards,
+};
+
+export default mockData;

--- a/components/atoms/Gnb.jsx
+++ b/components/atoms/Gnb.jsx
@@ -18,8 +18,8 @@ function Gnb() {
     logout();
   };
   return (
-    <header className="sticky z-10 top-0 flex justify-center">
-      <div className="w-full h-20 md:h-[70px] sm:h-[60px] max-w-[1480px] flex justify-between items-center mx-16 md:mx-10 sm:mx-5">
+    <header className="bg-[#0f0f0f] sticky z-10 top-0 flex justify-center">
+      <div className="w-full h-20 md:h-[70px] sm:h-[60px] max-w-[1480px] flex justify-between items-center mx-16 md:mx-5 sm:mx-4">
         <Image
           src={icMenu}
           alt="메뉴"
@@ -47,10 +47,15 @@ function Gnb() {
           </div>
         ) : (
           <div className="flex items-center sm:w-[22px]">
-            <p className="text-sm mr-6 sm:hidden" onClick={handleClickLogin}>
+            <p
+              className="text-sm mr-6 sm:hidden cursor-pointer hover:brightness-75 active:brightness-50"
+              onClick={handleClickLogin}
+            >
               로그인
             </p>
-            <p className="text-sm sm:hidden">회원가입</p>
+            <p className="text-sm sm:hidden cursor-pointer hover:brightness-75 active:brightness-50">
+              회원가입
+            </p>
           </div>
         )}
       </div>

--- a/components/atoms/Gnb.jsx
+++ b/components/atoms/Gnb.jsx
@@ -4,6 +4,7 @@ import icMenu from '@/assets/images/ic-menu.png';
 import icNotification from '@/assets/images/ic-notification.png';
 import { useAuth } from '@/contexts/AuthContext';
 import Image from 'next/image';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import Logo from './Logo';
 
@@ -18,13 +19,15 @@ function Gnb() {
   };
   return (
     <header className="sticky z-10 top-0 flex justify-center">
-      <div className="w-full h-20 md:h-[70px] sm:h-[60px] max-w-[1480px] flex justify-between items-center mx-[200px] md:mx-10 sm:mx-5">
+      <div className="w-full h-20 md:h-[70px] sm:h-[60px] max-w-[1480px] flex justify-between items-center mx-16 md:mx-10 sm:mx-5">
         <Image
           src={icMenu}
           alt="메뉴"
           className="w-[22px] lg:hidden md:hidden"
         />
-        <Logo />
+        <Link href={'/'}>
+          <Logo />
+        </Link>
         {isLoggedIn ? (
           <div className="flex items-center">
             <p className="text-sm font-bold mr-6 sm:hidden">1,540P</p>

--- a/components/atoms/PageContainer.jsx
+++ b/components/atoms/PageContainer.jsx
@@ -1,7 +1,7 @@
 function PageContainer({ children }) {
   return (
     <div className="flex justify-center">
-      <main className="w-full max-w-[1480px] mx-16 md:mx-10 sm:mx-5  mt-[60px] mb-[200px]">
+      <main className="w-full max-w-[1480px] mx-16 md:mx-5 sm:mx-4  mt-[60px] md:mt-10 sm:mt-5 mb-[200px]">
         {children}
       </main>
     </div>

--- a/components/atoms/PageContainer.jsx
+++ b/components/atoms/PageContainer.jsx
@@ -1,0 +1,11 @@
+function PageContainer({ children }) {
+  return (
+    <div className="flex justify-center">
+      <main className="w-full max-w-[1480px] mx-16 md:mx-10 sm:mx-5  mt-[60px] mb-[200px]">
+        {children}
+      </main>
+    </div>
+  );
+}
+
+export default PageContainer;

--- a/components/atoms/TitleText.jsx
+++ b/components/atoms/TitleText.jsx
@@ -1,0 +1,24 @@
+import clsx from 'clsx';
+
+/**
+ * TitleText 컴포넌트 사용법
+ * - children으로 표시할 텍스트를 받습니다
+ * - intent에 따라 크기와 글꼴이 정해집니다.
+ *   - xl: 마켓플레이스, 포토카드 생성
+ *   - lg: 나의 포토카드 판매하기
+ *   - md: 교환 희망 정보, {카드명}
+ *   - sm: 교환 희망 정보
+ *
+ * !! 위 예시는 달라질 수 있으니 figma를 참조하여 적용해 주세요.
+ */
+function TitleText({ children, intent }) {
+  const intentClassName = clsx({
+    'text-[62px] md:text-[48px] font-baskin': intent === 'xl',
+    'text-[46px] md:text-[40px] font-baskin': intent === 'lg',
+    'text-[40px] md:text-[32px] sm:text-[24px]': intent === 'md',
+    'text-[28px] md:text-[22px]': intent === 'sm',
+  });
+  return <p className={clsx(intentClassName)}>{children}</p>;
+}
+
+export default TitleText;

--- a/components/molecules/CardBottom.jsx
+++ b/components/molecules/CardBottom.jsx
@@ -2,6 +2,7 @@ import Button from '../atoms/Button';
 import Logo from '../atoms/Logo';
 
 function CardBottom({ card, intent }) {
+  console.log(card);
   const { price, salesEditionCount, totalEditionCount, proposalContent } = card;
   const isExchange = intent === 'exchange';
   const isShop = intent === 'shop';
@@ -29,9 +30,7 @@ function CardBottom({ card, intent }) {
             </div>
           ) : (
             <p className="font-normal text-lg sm:text-[10px]">
-              {isGallery
-                ? totalEditionCount - salesEditionCount
-                : salesEditionCount}
+              {isGallery ? card._count.cardEditions : salesEditionCount}
             </p>
           )}
         </div>

--- a/components/molecules/CardTop.jsx
+++ b/components/molecules/CardTop.jsx
@@ -34,8 +34,10 @@ function CardTop({ card, intent }) {
         )}
         <Image
           src={imgUrl}
-          alt="우리집 앞마당"
-          className={`w-[360px] mb-6 sm:mb-[10px] ${
+          alt={card}
+          width={360}
+          height={270}
+          className={`mb-6 sm:mb-[10px] ${
             !isOnSale && !isGallery ? ' opacity-30' : ''
           }`}
         />

--- a/components/molecules/Title.jsx
+++ b/components/molecules/Title.jsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Button from '../atoms/Button';
 import TitleText from '../atoms/TitleText';
 
@@ -11,7 +13,11 @@ import TitleText from '../atoms/TitleText';
  */
 function Title({ children, intent = 'xl', onClick, className }) {
   const buttonName =
-    children === '마켓플레이스' ? '내 포토카드 판매하기' : '포토카드 교환하기';
+    children === '마켓플레이스'
+      ? '내 포토카드 판매하기'
+      : children === '마이갤러리'
+      ? '포토카드 생성하기'
+      : '포토카드 교환하기';
   return (
     <div className={className}>
       <div className="border-b-2 border-[#eeeeee]] pb-4">
@@ -19,7 +25,7 @@ function Title({ children, intent = 'xl', onClick, className }) {
           <TitleText intent={intent}>{children}</TitleText>
           {onClick && (
             <div className="w-[440px] md:w-[342px]">
-              <Button>{buttonName}</Button>
+              <Button onClick={onClick}>{buttonName}</Button>
             </div>
           )}
         </div>

--- a/components/molecules/Title.jsx
+++ b/components/molecules/Title.jsx
@@ -1,9 +1,28 @@
-function Title({ children, intent, onClick }) {
+import Button from '../atoms/Button';
+import TitleText from '../atoms/TitleText';
+
+/**
+ * Title 컴포넌트 사용 방법
+ * - children으로 표시할 텍스트를 받습니다.
+ * - onClick이 있는 경우 버튼이 표시되고, 버튼명은 children에 의해 자동으로 결정됩니다.
+ * - intent에 따라 버튼 크기와 TitleText 크기/글꼴이 결정됩니다.
+ *
+ * !! 모바일에서 숨겨야할 경우 Title의 className에 sm:hidden을 입력해 주세요.
+ */
+function Title({ children, intent = 'xl', onClick, className }) {
+  const buttonName =
+    children === '마켓플레이스' ? '내 포토카드 판매하기' : '포토카드 교환하기';
   return (
-    <div>
-      <div>
-        <p>{children}</p>
-        <Button></Button>
+    <div className={className}>
+      <div className="border-b-2 border-[#eeeeee]] pb-4">
+        <div className="flex items-center justify-between ">
+          <TitleText intent={intent}>{children}</TitleText>
+          {onClick && (
+            <div className="w-[440px] md:w-[342px]">
+              <Button>{buttonName}</Button>
+            </div>
+          )}
+        </div>
       </div>
       <div></div>
     </div>

--- a/components/molecules/Title.jsx
+++ b/components/molecules/Title.jsx
@@ -1,0 +1,13 @@
+function Title({ children, intent, onClick }) {
+  return (
+    <div>
+      <div>
+        <p>{children}</p>
+        <Button></Button>
+      </div>
+      <div></div>
+    </div>
+  );
+}
+
+export default Title;

--- a/components/organisms/Card.jsx
+++ b/components/organisms/Card.jsx
@@ -12,11 +12,9 @@ import CardTop from '../molecules/CardTop';
  */
 function Card({ card, intent = 'shop' }) {
   return (
-    <div className="h-[100vh] flex justify-center items-center bg-[#0f0f0f]">
-      <div className="w-[440px] md:w-[342px] sm:w-[170px] border border-card-border p-10 md:p-5 sm:p-[10px]">
-        <CardTop card={card} intent={intent} />
-        <CardBottom card={card} intent={intent} />
-      </div>
+    <div className="w-full max-w-[440px] md:max-w-[342px] sm:max-w-[170px] border border-card-border p-10 md:p-5 sm:p-[10px]">
+      <CardTop card={card} intent={intent} />
+      <CardBottom card={card} intent={intent} />
     </div>
   );
 }

--- a/components/organisms/CardList.jsx
+++ b/components/organisms/CardList.jsx
@@ -1,0 +1,15 @@
+import Card from './Card';
+
+function CardList({ cards }) {
+  return (
+    <div className="flex justify-center">
+      <div className="grid gap-20 md:gap-5 sm:gap-4 grid-cols-3 md:grid-cols-2 sm:grid-cols-2">
+        {cards.map((card) => (
+          <Card key={card.id} intent="gallery" card={card} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default CardList;

--- a/components/organisms/MarketPlaceHeader.jsx
+++ b/components/organisms/MarketPlaceHeader.jsx
@@ -1,0 +1,21 @@
+'use client';
+
+import Title from '../molecules/Title';
+
+function MarketPlaceHeader() {
+  return (
+    <div className="mb-[60px] md:mb-10 sm:mb-5">
+      <Title
+        intent="xl"
+        onClick={() => {
+          alert('구현중');
+        }}
+        className="sm:hidden"
+      >
+        마켓플레이스
+      </Title>
+    </div>
+  );
+}
+
+export default MarketPlaceHeader;

--- a/components/organisms/MyGalleryHeader.jsx
+++ b/components/organisms/MyGalleryHeader.jsx
@@ -1,0 +1,21 @@
+'use client';
+
+import Title from '../molecules/Title';
+
+function MyGalleryHeader() {
+  return (
+    <div className="mb-[60px] md:mb-10 sm:mb-5">
+      <Title
+        intent="xl"
+        onClick={() => {
+          alert('구현중');
+        }}
+        className="sm:hidden"
+      >
+        마이갤러리
+      </Title>
+    </div>
+  );
+}
+
+export default MyGalleryHeader;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,17 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  reactStrictMode: false,
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'http',
+        hostname: 'localhost',
+        port: '5050',
+        pathname: '/static/**',
+        search: '',
+      },
+    ],
+  },
+};
 
 export default nextConfig;


### PR DESCRIPTION
#21 

- 페이지 컨테이너 적용(메인 콘텐츠 감싸는 용도, /components/atoms/PageContainer.jsx)

<img width="895" alt="Image" src="https://github.com/user-attachments/assets/65f965de-1947-4b38-b2f5-9cf7602e8d79" />

<img width="1023" alt="Image" src="https://github.com/user-attachments/assets/55926a59-cb77-4038-b8ee-d93b5b700ca5" />

- 타이틀 컴포넌트 구현(/components/organisms/Title.jsx, /components/atoms/TitleText.jsx)

<img width="471" alt="Image" src="https://github.com/user-attachments/assets/0fa4dd60-2372-41dc-8813-e94287708d0d" />

- 마켓플레이스 페이지 UI 구현(반응형)

<img width="1422" alt="Image" src="https://github.com/user-attachments/assets/3ed8fbb4-39ba-4ba6-9dd3-68592a5b2c66" />

- mock data 생성(카드 데이터 3개)
  - /assets/data/mock.js
- cardsApi.js
  - getMyCardsOfGallery(갤러리 카드 전체 조회), getMyCardOfGallery(갤러리 카드 상세 조회)
- 마이갤러리 페이지 구현
  - SSR 적용(getMyCardsOfGallery)

<img width="1418" alt="Image" src="https://github.com/user-attachments/assets/56f4f4e4-f751-47a3-84c7-cf404cea4be8" />
