### PR TITLE
[조형민] 카드 구매하기 외 Feature/58

### DIFF
--- a/api/cards/cards.api.js
+++ b/api/cards/cards.api.js
@@ -42,7 +42,7 @@ const getMyCardsOfGallery = async ({
   }
 };
 
-// 카드 상세 정보 조회
+// 마이갤러리 카드 상세 정보 조회
 const getMyCardOfGallery = async (cardId) => {
   try {
     const url = `/cards/me/gallery/${cardId}`;
@@ -53,10 +53,30 @@ const getMyCardOfGallery = async (cardId) => {
   }
 };
 
+// 나의 판매 포토 목록 조회
+const getMyCardsOfSales = async ({
+  orderBy = '최신 순',
+  grade = '등급',
+  genre = '장르',
+  keyword = '',
+}) => {
+  try {
+    const url = '/cards/me/sales';
+    const response = await client.get(url, {
+      params: { orderBy, grade, genre, keyword },
+    });
+
+    return response.data;
+  } catch (error) {
+    errorHandler(error);
+  }
+};
+
 const cardsApi = {
   createCard,
   getMyCardsOfGallery,
   getMyCardOfGallery,
+  getMyCardsOfSales,
 };
 
 export default cardsApi;

--- a/api/shops/shops.api.js
+++ b/api/shops/shops.api.js
@@ -32,9 +32,22 @@ const getShop = async (shopId) => {
   }
 };
 
+// 상점에서 카드 구매하기
+const purchaseCards = async (shopId, dto) => {
+  try {
+    const url = `/shops/${shopId}/purchase`;
+    const response = client.post(url, dto);
+
+    return (await response).data;
+  } catch (error) {
+    errorHandler(error);
+  }
+};
+
 const shopsApi = {
   getShops,
   getShop,
+  purchaseCards,
 };
 
 export default shopsApi;

--- a/api/shops/shops.api.js
+++ b/api/shops/shops.api.js
@@ -1,6 +1,18 @@
 import { client, errorHandler } from '../client';
 
-// 상점 shop 목록 조회
+// 상점 생성
+const createShop = async (dto) => {
+  try {
+    const url = '/shops';
+    const reponse = await client.post(url, dto);
+
+    return reponse.data;
+  } catch (error) {
+    errorHandler(error);
+  }
+};
+
+// 상점 목록 조회
 const getShops = async ({
   orderBy = '최신 순',
   grade = '등급',
@@ -32,6 +44,18 @@ const getShop = async (shopId) => {
   }
 };
 
+// 상점 삭제(판매 내리기)
+const deleteShop = async (shopId) => {
+  try {
+    const url = `/shops/${shopId}`;
+    const response = await client.delete(url);
+
+    return response.data;
+  } catch (error) {
+    errorHandler(error);
+  }
+};
+
 // 상점에서 카드 구매하기
 const purchaseCards = async (shopId, dto) => {
   try {
@@ -45,8 +69,10 @@ const purchaseCards = async (shopId, dto) => {
 };
 
 const shopsApi = {
+  createShop,
   getShops,
   getShop,
+  deleteShop,
   purchaseCards,
 };
 

--- a/app/(providers)/(root)/[shopId]/page.jsx
+++ b/app/(providers)/(root)/[shopId]/page.jsx
@@ -9,7 +9,7 @@ async function ShopDetailPage({ params }) {
         <p className="font-baskinB text-2xl md:text-base text-[#a4a4a4] mb-[60px] md:mb-10 sm:hidden">
           마켓플레이스
         </p>
-        <Detail dataId={shopId} intent="seller" />
+        <Detail dataId={shopId} intent="market" />
       </div>
     </PageContainer>
   );

--- a/app/(providers)/(root)/auth/log-in/page.jsx
+++ b/app/(providers)/(root)/auth/log-in/page.jsx
@@ -7,7 +7,7 @@ import PageContainer from '@/components/atoms/PageContainer';
 import InputPassword from '@/components/molecules/InputPassword';
 import InputText from '@/components/molecules/InputText';
 import { useAuth } from '@/contexts/AuthContext';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 
@@ -19,9 +19,12 @@ function LoginPage() {
     defaultValues: { email: '', password: '' },
   });
 
+  const queryClient = useQueryClient();
+
   const { mutate: login } = useMutation({
     mutationFn: (data) => usersApi.logIn(data),
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['me'] });
       router.replace('/');
       authLogin();
     },

--- a/app/(providers)/(root)/auth/sign-up/page.jsx
+++ b/app/(providers)/(root)/auth/sign-up/page.jsx
@@ -7,7 +7,7 @@ import PageContainer from '@/components/atoms/PageContainer';
 import InputPassword from '@/components/molecules/InputPassword';
 import InputText from '@/components/molecules/InputText';
 import { useAuth } from '@/contexts/AuthContext';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -16,6 +16,7 @@ function SignUpPage() {
   const { login: authLogin } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const queryClient = useQueryClient();
 
   const router = useRouter();
   const { handleSubmit, control, getValues, setError } = useForm({
@@ -50,6 +51,7 @@ function SignUpPage() {
   const { mutate: login } = useMutation({
     mutationFn: (data) => usersApi.logIn(data),
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['me'] });
       router.replace('/');
       authLogin();
     },

--- a/app/(providers)/(root)/my-cards/sales/page.jsx
+++ b/app/(providers)/(root)/my-cards/sales/page.jsx
@@ -1,5 +1,12 @@
-function MyCardsSalesPage() {
-  return <div>MyCardsSales</div>;
+import PageContainer from '@/components/atoms/PageContainer';
+import MySales from '@/components/templates/MySales';
+
+async function MyCardsSalesPage() {
+  return (
+    <PageContainer>
+      <MySales />
+    </PageContainer>
+  );
 }
 
 export default MyCardsSalesPage;

--- a/components/atoms/Gnb.jsx
+++ b/components/atoms/Gnb.jsx
@@ -1,16 +1,24 @@
 'use client';
 
+import usersApi from '@/api/users/users.api';
 import icMenu from '@/assets/images/ic-menu.png';
 import icNotification from '@/assets/images/ic-notification.png';
 import { useAuth } from '@/contexts/AuthContext';
+import { useQuery } from '@tanstack/react-query';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import Logo from './Logo';
 
 function Gnb() {
-  const { isLoggedIn, logout, userInfo, isAuthInitialized } = useAuth();
+  const { isLoggedIn, logout, isAuthInitialized } = useAuth();
   const router = useRouter();
+
+  const { data: user } = useQuery({
+    queryKey: ['me'],
+    queryFn: usersApi.getMe,
+  });
+
   const handleClickLogin = () => {
     router.push('/auth/log-in');
   };
@@ -36,7 +44,7 @@ function Gnb() {
           (isLoggedIn ? (
             <div className="flex items-center">
               <p className="text-sm font-bold mr-6 sm:hidden">
-                {userInfo ? userInfo.point : ''}P
+                {user ? user.point : ''}P
               </p>
               <Image
                 src={icNotification}
@@ -45,7 +53,7 @@ function Gnb() {
               />
               <Link href="/my-cards/gallery">
                 <p className="font-baskin text-lg mr-6 sm:hidden">
-                  {userInfo ? userInfo.nickname : ''}
+                  {user ? user.nickname : ''}
                 </p>
               </Link>
               <div className="w-[1px] h-5 bg-[#5a5a5a] mr-6 sm:hidden"></div>

--- a/components/atoms/Gnb.jsx
+++ b/components/atoms/Gnb.jsx
@@ -43,9 +43,11 @@ function Gnb() {
         {isAuthInitialized &&
           (isLoggedIn ? (
             <div className="flex items-center">
-              <p className="text-sm font-bold mr-6 sm:hidden">
-                {user ? user.point : ''}P
-              </p>
+              <Link href="/my-cards/sales">
+                <p className="text-sm font-bold mr-6 sm:hidden">
+                  {user ? user.point : ''}P
+                </p>
+              </Link>
               <Image
                 src={icNotification}
                 alt="알림아이콘"

--- a/components/molecules/CardDetailBottom.jsx
+++ b/components/molecules/CardDetailBottom.jsx
@@ -2,7 +2,7 @@
 
 import shopsApi from '@/api/shops/shops.api';
 import exchangeIcon from '@/assets/images/ic-exchange.png';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
@@ -42,10 +42,13 @@ function CardDetailBottom({
     exchangeDesc,
   } = cardDetail;
 
+  const queryClient = useQueryClient();
+
   const { mutate: purchaseCards } = useMutation({
     mutationFn: (dto) => shopsApi.purchaseCards(dataId, dto),
     onSuccess: () => {
       // TODO: 구매 성공 페이지로 이동
+      queryClient.invalidateQueries({ queryKey: ['me'] });
       router.replace('/');
     },
     onError: () => {

--- a/components/molecules/CardDetailBottom.jsx
+++ b/components/molecules/CardDetailBottom.jsx
@@ -1,7 +1,10 @@
 'use client';
 
+import shopsApi from '@/api/shops/shops.api';
 import exchangeIcon from '@/assets/images/ic-exchange.png';
+import { useMutation } from '@tanstack/react-query';
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import Button from '../atoms/Button';
@@ -16,8 +19,10 @@ function CardDetailBottom({
   onEditSale,
   onStopSale,
   onStartSale,
+  dataId,
 }) {
   const [count, setCount] = useState(1);
+  const router = useRouter();
   const {
     register,
     formState: { errors },
@@ -33,9 +38,34 @@ function CardDetailBottom({
     exchangeGrade,
     remainingCount,
     price,
-    purchacedPrice,
+    paidPrice,
     exchangeDesc,
   } = cardDetail;
+
+  const { mutate: purchaseCards } = useMutation({
+    mutationFn: (dto) => shopsApi.purchaseCards(dataId, dto),
+    onSuccess: () => {
+      // TODO: 구매 성공 페이지로 이동
+      router.replace('/');
+    },
+    onError: () => {
+      // TODO:구매 실패 페이지로 이동
+    },
+  });
+
+  const handleClickPurchase = () => {
+    if (remainingCount === 0) return;
+    // TODO: 구매 확인 모달창 띄우고, 해당 창에서 '구매하기'를 하면 아래 함수 실행
+    const data = {
+      price,
+      purchaseCount: count,
+    };
+    purchaseCards(data);
+  };
+
+  const handleClickExchange = () => {
+    if (remainingCount === 0) return;
+  };
 
   // 경우 수는 buyer, seller, exchange, myCardSale
   const renderContent = () => {
@@ -59,8 +89,21 @@ function CardDetailBottom({
                 <span className="font-light text-[#a5a5a5]">({count}장)</span>
               </p>
             </div>
-            <Button onClick={onPurchase} className="mt-8 lg:mt-16" size="h75">
+            <Button
+              onClick={handleClickPurchase}
+              className="mt-8 lg:mt-16"
+              size="h75"
+              disabled={remainingCount === 0}
+            >
               포토카드 구매하기
+            </Button>
+            <Button
+              onClick={handleClickExchange}
+              className="mt-8 lg:mt-[34px]"
+              size="h75"
+              disabled={remainingCount === 0}
+            >
+              포토카드 교환하기
             </Button>
           </>
         );

--- a/components/molecules/CardDetailBottom.jsx
+++ b/components/molecules/CardDetailBottom.jsx
@@ -56,9 +56,17 @@ function CardDetailBottom({
     },
   });
 
+  const { mutate: deleteShop } = useMutation({
+    mutationFn: () => shopsApi.deleteShop(dataId),
+    onSuccess: () => {
+      // TODO: 삭제 성공 페이지로 이동
+      router.push('/');
+    },
+  });
+
   const handleClickPurchase = () => {
     if (remainingCount === 0) return;
-    // TODO: 구매 확인 모달창 띄우고, 해당 창에서 '구매하기'를 하면 아래 함수 실행
+    // TODO: 확인 모달창 띄우고, 해당 창에서 '구매하기'를 하면 아래 함수 실행
     const data = {
       price,
       purchaseCount: count,
@@ -68,6 +76,11 @@ function CardDetailBottom({
 
   const handleClickExchange = () => {
     if (remainingCount === 0) return;
+  };
+
+  const handleClickStopSale = () => {
+    // TODO: 확인 모달창 띄우고, 해당 창에서 '판매 내리기'를 하면 아래 함수 실행
+    deleteShop();
   };
 
   // 경우 수는 buyer, seller, exchange, myCardSale
@@ -143,7 +156,11 @@ function CardDetailBottom({
                 <Button onClick={onEditSale} size="h75">
                   수정하기
                 </Button>
-                <Button onClick={onStopSale} size="h75" intent="secondary">
+                <Button
+                  onClick={handleClickStopSale}
+                  size="h75"
+                  intent="secondary"
+                >
                   판매 내리기
                 </Button>
               </div>

--- a/components/molecules/CardTop.jsx
+++ b/components/molecules/CardTop.jsx
@@ -4,12 +4,20 @@ import GradeCardBadge from '../atoms/GradeCardBadge';
 import SaleStatusChip from '../atoms/SaleStatusChip';
 
 function CardTop({ card, intent }) {
-  const { imgUrl, name, grade, genre, nickname, salesCount, purchacedPrice } =
-    card;
+  const {
+    imgUrl,
+    name,
+    grade,
+    genre,
+    nickname,
+    salesCount,
+    remainingCount,
+    paidPrice,
+  } = card;
   const isGallery = intent === 'gallery';
   const isExchange = intent === 'exchange';
   const isShop = intent === 'shop';
-  const isOnSale = salesCount !== 0;
+  const isOnSale = remainingCount !== 0;
 
   return (
     <div>
@@ -18,15 +26,16 @@ function CardTop({ card, intent }) {
           <SaleStatusChip isSale={false} />
         </div>
       )}
-      {!isOnSale && !isGallery && (
-        <Image
-          src={soldOut}
-          alt="매진"
-          className="z-10 absolute top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%] transform w-[230px] md:w-[200px] sm:w-[112px]"
-        />
-      )}
+
       {imgUrl ? (
         <div className="aspect-[360/270] relative mb-6 sm:mb-[10px]">
+          {!isOnSale && !isGallery && (
+            <Image
+              src={soldOut}
+              alt="매진"
+              className="z-10 absolute top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%] transform w-[230px] md:w-[200px] sm:w-[112px]"
+            />
+          )}
           <Image
             src={imgUrl}
             alt="카드 이미지"
@@ -52,13 +61,13 @@ function CardTop({ card, intent }) {
             <p className="text-[#a4a4a4] sm:text-[10px] font-normal">{genre}</p>
             <div className="w-[1px] h-5 bg-[#5a5a5a] mx-[10px] sm:mx-[5px] md:hidden sm:hidden"></div>
             <div className="flex md:hidden sm:hidden">
-              <p>{purchacedPrice} P</p>
+              <p>{paidPrice} P</p>
               <p className="text-[#a4a4a4]">&nbsp;에 구매</p>
             </div>
           </div>
           <div className="flex justify-between lg:hidden">
             <div className="flex">
-              <p className="sm:text-[10px]">{purchacedPrice} P</p>
+              <p className="sm:text-[10px]">{paidPrice} P</p>
               <p className="text-[#a4a4a4] sm:text-[10px]">&nbsp;에 구매</p>
             </div>
             <p className="underline font-normal sm:text-[10px]">{nickname}</p>

--- a/components/molecules/UserCardsSummary.jsx
+++ b/components/molecules/UserCardsSummary.jsx
@@ -1,12 +1,14 @@
 import GradeMyCardCount from '../atoms/GradeMyCardCount';
 
-function UserCardsSummary({ nickname, userSummary }) {
+function UserCardsSummary({ nickname, userSummary, intent = 'notPossesion' }) {
+  const label =
+    intent === 'inPossesion' ? '보유한 포토카드' : '판매중인 포토카드';
   const totalCount = Object.values(userSummary).reduce((a, b) => a + b);
   return (
     <div className="mt-10 sm:mt-5">
       <div className="flex items-center">
         <p className="text-2xl font-bold mr-[10px]">
-          {nickname}님이 보유한 포토카드
+          {nickname}님이 {label}
         </p>
         <p className="text-xl text-[#a4a4a4]">({totalCount}장)</p>
       </div>

--- a/components/organisms/CardDetail.jsx
+++ b/components/organisms/CardDetail.jsx
@@ -7,8 +7,8 @@ import CardDetailTop from '../molecules/CardDetailTop';
  * - cardDetail : card 상세정보 데이터
  *
  * - topIntent : 카드 상단 형태 구분
- *   - detailAll : 해당 카드의 모든 정보 노출
- *   - myCardDetail : 판매중 나의 카드 상세 정보에서만 사용* , grade,genre,nickname 영역만 노출
+ *   - detailAll : 해당 카드의 모든 정보 노출(gallery외의 상세 화면에서 사용)
+ *   - myCardDetail : 판매중 나의 카드 상세 정보에서만 사용* , grade,genre,nickname 영역만 노출 - 판매 모달에서 사용
  *   - gallery : 해당 카드의 모든정보 노출 단(기존 잔여에서 보유량으로 변경 됨)
  *
  * - bottomIntent : 카드 하단 형태 구분
@@ -17,12 +17,16 @@ import CardDetailTop from '../molecules/CardDetailTop';
  *   - exchange : 교환 희망 정보 입력 모달(판매할 포토카드 선택 후)
  *   - gallery : 마이 갤러리 카드 상세
  */
-function CardDetail({ cardDetail, topIntent, bottomIntent }) {
+function CardDetail({ cardDetail, topIntent, bottomIntent, dataId }) {
   return (
     <div className="flex justify-center items-center bg-[#0f0f0f] gap-4">
       <div className="w-[440px] md:w-[342px] sm:w-[342px] px-0 py-0">
         <CardDetailTop cardDetail={cardDetail} topIntent={topIntent} />
-        <CardDetailBottom cardDetail={cardDetail} bottomIntent={bottomIntent} />
+        <CardDetailBottom
+          cardDetail={cardDetail}
+          bottomIntent={bottomIntent}
+          dataId={dataId}
+        />
       </div>
     </div>
   );

--- a/components/templates/Detail.jsx
+++ b/components/templates/Detail.jsx
@@ -2,7 +2,7 @@
 
 import cardsApi from '@/api/cards/cards.api';
 import shopsApi from '@/api/shops/shops.api';
-import { useAuth } from '@/contexts/AuthContext';
+import usersApi from '@/api/users/users.api';
 import { useQuery } from '@tanstack/react-query';
 import Image from 'next/image';
 import GradeCardBadge from '../atoms/GradeCardBadge';
@@ -15,8 +15,11 @@ import CardDetail from '../organisms/CardDetail';
  * - dataId: shop 또는 card의 id
  */
 function Detail({ dataId, intent = 'gallery' }) {
-  const { userInfo } = useAuth();
-  const currentUser = userInfo.nickname;
+  const { data: user } = useQuery({
+    queryKey: ['me'],
+    queryFn: usersApi.getMe,
+  });
+  const currentUser = user?.nickname || '';
   const { data } = useQuery({
     queryKey: ['shop', { dataId }],
     queryFn: () => {

--- a/components/templates/Detail.jsx
+++ b/components/templates/Detail.jsx
@@ -2,6 +2,7 @@
 
 import cardsApi from '@/api/cards/cards.api';
 import shopsApi from '@/api/shops/shops.api';
+import { useAuth } from '@/contexts/AuthContext';
 import { useQuery } from '@tanstack/react-query';
 import Image from 'next/image';
 import GradeCardBadge from '../atoms/GradeCardBadge';
@@ -10,10 +11,12 @@ import CardDetail from '../organisms/CardDetail';
 
 /**
  * Detail 컴포넌트 설정 방법
- * - intent: gallery(기본값), seller, buyer
+ * - intent: gallery(마이갤러리에서 상세 조회), market(마켓플레이스에서 상세 조회)
  * - dataId: shop 또는 card의 id
  */
 function Detail({ dataId, intent = 'gallery' }) {
+  const { userInfo } = useAuth();
+  const currentUser = userInfo.nickname;
   const { data } = useQuery({
     queryKey: ['shop', { dataId }],
     queryFn: () => {
@@ -23,6 +26,7 @@ function Detail({ dataId, intent = 'gallery' }) {
   });
 
   if (!data) return null;
+
   return (
     <div className={`${intent !== 'gallery'}?mt-[60px]:""`}>
       <Title intent="md">{data.name}</Title>
@@ -39,17 +43,24 @@ function Detail({ dataId, intent = 'gallery' }) {
           <div>
             <CardDetail
               cardDetail={data}
-              topIntent={'gallery'}
-              bottomIntent={intent}
+              topIntent={intent === 'gallery' ? 'gallery' : 'detailAll'}
+              bottomIntent={
+                intent === 'gallery'
+                  ? intent
+                  : currentUser === data.seller
+                  ? 'seller'
+                  : 'buyer'
+              }
+              dataId={dataId}
             />
           </div>
         </div>
       </div>
       <div className="mt-[120px]">
-        {intent === 'seller' ? (
+        {intent !== 'gallery' && currentUser === data.seller ? (
           <Title intent="md">교환 제시 목록</Title>
         ) : // 응답 목록에 아직 포함되어 있지 않음(2025.02.21)
-        intent === 'buyer' ? (
+        intent !== 'gallery' && currentUser !== data.seller ? (
           <div>
             <Title intent="md">교환 희망 정보</Title>
             <p className="mt-[66px] mb-5 text-2xl font-bold">

--- a/components/templates/MarketPlace.jsx
+++ b/components/templates/MarketPlace.jsx
@@ -57,7 +57,7 @@ function MarketPlace({ initialData }) {
               size="md"
             />
           </form>
-          <div className="flex shrink-0 ml-[60px]">
+          <div className="flex shrink-0 ml-[60px] md:ml-[30px]">
             <Dropdown
               width="w-[134px]"
               label="등급"

--- a/components/templates/MyGallery.jsx
+++ b/components/templates/MyGallery.jsx
@@ -1,9 +1,9 @@
 'use client';
 
 import cardsApi from '@/api/cards/cards.api';
+import usersApi from '@/api/users/users.api';
 import icDropdown from '@/assets/images/ic-dropdown.png';
 import constants from '@/constant';
-import { useAuth } from '@/contexts/AuthContext';
 import { useQuery } from '@tanstack/react-query';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
@@ -22,9 +22,12 @@ function MyGallery({ initialData }) {
   const [keyword, setKeyword] = useState('');
   const router = useRouter();
 
-  const { userInfo } = useAuth();
-
   const { handleSubmit, control } = useForm({ defaultValues: { search: '' } });
+
+  const { data: user } = useQuery({
+    queryKey: ['me'],
+    queryFn: usersApi.getMe,
+  });
 
   const searchOptions = { orderBy, grade, genre, keyword };
   const { data, isPending } = useQuery({
@@ -57,7 +60,7 @@ function MyGallery({ initialData }) {
           마이갤러리
         </Title>
         <UserCardsSummary
-          nickname={userInfo?.nickname}
+          nickname={user?.nickname}
           userSummary={data?.userSummary}
         />
         <div className="flex justify-between items-center mt-5 sm:hidden">

--- a/components/templates/MyGallery.jsx
+++ b/components/templates/MyGallery.jsx
@@ -72,7 +72,7 @@ function MyGallery({ initialData }) {
               size="md"
             />
           </form>
-          <div className="flex shrink-0 ml-[60px]">
+          <div className="flex shrink-0 ml-[60px] md:ml-[30px]">
             <Dropdown
               width="w-[134px]"
               label="등급"

--- a/components/templates/MySales.jsx
+++ b/components/templates/MySales.jsx
@@ -32,7 +32,7 @@ function MySales() {
   const searchOptions = { orderBy, grade, genre, keyword };
   const { data, isPending } = useQuery({
     queryKey: ['cards', { ...searchOptions }],
-    queryFn: () => cardsApi.getMyCardsOfGallery(searchOptions),
+    queryFn: () => cardsApi.getMyCardsOfSales(searchOptions),
     staleTime: 0,
     placeholderData: (prevData) => prevData, // 깜박임을 없애기 위해 넣었는데..잘 안 됨(2025.02.19)
     retry: 0,
@@ -43,8 +43,8 @@ function MySales() {
   };
 
   const cards = data?.cards || [];
-  // console.log('totalEditions', data?.totalEditions);
-  // console.log('cards', data?.cards);
+  console.log('totalEditions', data?.totalEditions);
+  console.log('cards', data?.cards);
 
   if (isPending) return null;
   return (

--- a/components/templates/MySales.jsx
+++ b/components/templates/MySales.jsx
@@ -15,7 +15,7 @@ import Title from '../molecules/Title';
 import UserCardsSummary from '../molecules/UserCardsSummary';
 import CardList from '../organisms/CardList';
 
-function MyGallery() {
+function MySales() {
   const [orderBy, setOrderBy] = useState('최신 순');
   const [grade, setGrade] = useState('등급');
   const [genre, setGenre] = useState('장르');
@@ -50,19 +50,12 @@ function MyGallery() {
   return (
     <div>
       <div className="mb-[60px] md:mb-10 sm:mb-5">
-        <Title
-          intent="xl"
-          onClick={() => {
-            router.push('/my-cards/gallery/create');
-          }}
-          className="sm:hidden"
-        >
-          마이갤러리
+        <Title intent="xl" className="sm:hidden">
+          나의 판매 포토카드
         </Title>
         <UserCardsSummary
           nickname={user?.nickname}
           userSummary={data?.userSummary}
-          intent="inPossesion"
         />
         <div className="flex justify-between items-center mt-5 sm:hidden">
           <form onSubmit={handleSubmit(handleSubmitSearch)}>
@@ -84,6 +77,12 @@ function MyGallery() {
               width="w-[134px]"
               label="장르"
               options={constants.CARD_GENRES}
+              onSelect={setGenre}
+            />
+            <Dropdown
+              width="w-[134px]"
+              label="판매방법"
+              options={constants.HOW_TO_SALE}
               onSelect={setGenre}
             />
           </div>
@@ -110,4 +109,4 @@ function MyGallery() {
   );
 }
 
-export default MyGallery;
+export default MySales;

--- a/constant/index.js
+++ b/constant/index.js
@@ -2,12 +2,14 @@ const CARD_GRADES = ['COMMON', 'RARE', 'SUPER RARE', 'LEGENDARY'];
 const CARD_GENRES = ['풍경', '인물', '사물', '여행'];
 const CARD_ON_SALE = ['판매 중', '판매 완료'];
 const SORT_OPTIONS = ['최신 순', '오래된 순', '높은 가격순', '낮은 가격순'];
+const HOW_TO_SALE = ['판매중', '교환 제시 대기 중'];
 
 const constants = {
   CARD_GRADES,
   CARD_GENRES,
   CARD_ON_SALE,
   SORT_OPTIONS,
+  HOW_TO_SALE,
 };
 
 export default constants;

--- a/contexts/AuthContext.jsx
+++ b/contexts/AuthContext.jsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { client } from '@/api/client';
-import usersApi from '@/api/users/users.api';
 import { usePathname, useRouter } from 'next/navigation';
 import { createContext, useContext, useEffect, useState } from 'react';
 
@@ -12,7 +11,6 @@ export const useAuth = () => useContext(AuthContext);
 export function AuthProvider({ children }) {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [isAuthInitialized, setIsAuthInitialized] = useState(false);
-  const [userInfo, setUserInfo] = useState(null);
   const pathName = usePathname();
   const router = useRouter();
 
@@ -42,10 +40,6 @@ export function AuthProvider({ children }) {
         const accessToken = localStorage.getItem('accessToken');
         if (!accessToken) return;
 
-        const user = await usersApi.getMe();
-        // if (!user) return;
-
-        setUserInfo(user);
         setIsLoggedIn(true);
       } catch (error) {
         console.error('refreshToken이 없거나 만료', error);
@@ -59,7 +53,6 @@ export function AuthProvider({ children }) {
   const value = {
     isLoggedIn,
     isAuthInitialized,
-    userInfo,
     login,
     logout,
   };


### PR DESCRIPTION
### 카드 구매하기 함수 추가(cardsApi.js에 purchaseCards추가)
- CardDetailBottom.jsx의 '포토카드 구매하기' 버튼 클릭 시 실행
### Detail.jsx 변경
- intent를 'gallery'와 'market'의 2가지로 변경
- 'market'의 'seller', 'buyer' 구분은 실제 상세 페이지 로딩 시 분기
### 유저 정보 로딩 방식 변경
- 기존: AuthContext에서 전역으로 관리
- 변경: 필요한 곳에서 useQuery로 로딩
- 변경 이유: 로그아웃 후 다른 아이디로 로그인 시, 카드 구매/교환 시 등의 경우에 Gnb의 유저 정보 변경을 처리하기 위해
### MySales 페이지 구현 및 UserSummary 컴포넌트 수정
- '나의 판매 포토카드' 페이지 구현
  - cardsApi.js에 getMyCardsOfSales 추가
<img width="993" alt="image" src="https://github.com/user-attachments/assets/3181d1c9-d8cd-4c74-84bf-fa5188b84ecc" />

- UserSummary 컴포넌트 수정
  - 카드의 개수가 아닌 에디션 각각의 개수를 카운팅하도록 수정
<img width="526" alt="image" src="https://github.com/user-attachments/assets/981c6ed7-0226-457a-9ccf-19cb5df7b7a4" />
