### PR TITLE
[조형민] 알림 구현 Feature/90

### DIFF
--- a/api/notifications/notifications.api.js
+++ b/api/notifications/notifications.api.js
@@ -1,0 +1,30 @@
+import { client, errorHandler } from '../client';
+
+const sendNotification = async (dto) => {
+  try {
+    const url = '/notifications';
+    const response = await client.post(url, dto);
+
+    return response.data;
+  } catch (error) {
+    errorHandler(error);
+  }
+};
+
+const getNotificationsOfMe = async () => {
+  try {
+    const url = '/notifications/me';
+    const response = await client.get(url);
+
+    return response.data;
+  } catch (error) {
+    errorHandler(error);
+  }
+};
+
+const notificationsApi = {
+  sendNotification,
+  getNotificationsOfMe,
+};
+
+export default notificationsApi;

--- a/api/notifications/notifications.api.js
+++ b/api/notifications/notifications.api.js
@@ -1,6 +1,7 @@
 import { client, errorHandler } from '../client';
 
 const sendNotification = async (dto) => {
+  console.log('do!!!!', dto);
   try {
     const url = '/notifications';
     const response = await client.post(url, dto);

--- a/api/shops/shops.api.js
+++ b/api/shops/shops.api.js
@@ -140,6 +140,19 @@ const approveExchange = async (exchangeId, dto) => {
   }
 };
 
+// 교환 제안 거절하기
+// -> 교환 취소와 완전히 동일하지만, 알림 전송을 위해 요청 API를 구분
+const refuseExchange = async (exchangeId, dto) => {
+  try {
+    const url = `/shops/exchanges/${exchangeId}`;
+    const reponse = await client.put(url, dto);
+
+    return reponse.data;
+  } catch (error) {
+    errorHandler(error);
+  }
+};
+
 const shopsApi = {
   createShop,
   getShops,
@@ -151,6 +164,7 @@ const shopsApi = {
   proposeExchange,
   cancelProposeExchange,
   approveExchange,
+  refuseExchange,
   updateShop,
 };
 

--- a/components/molecules/CardBottom.jsx
+++ b/components/molecules/CardBottom.jsx
@@ -35,15 +35,32 @@ function CardBottom({ card, intent, isProposedByMe = false }) {
   const { mutate: cancelProposeExchange } = useMutation({
     mutationFn: () => shopsApi.cancelProposeExchange(id, { editionId }),
     onSuccess: () => {
-      // shop의 내가 제시한 교환 목록 갱신 - 취소 시
+      // shop의 내가 제시한 교환 목록 갱신
       queryClient.invalidateQueries({
         queryKey: ['my-exchanges', { shopId }],
       });
-      // shop의 내가 제안받은 교환 목록 갱신 - 거절 시
+    },
+  });
+
+  const { mutate: refuseProposeExchange } = useMutation({
+    mutationFn: () => shopsApi.refuseExchange(id, { editionId }),
+    onSuccess: () => {
+      // shop의 내가 제안받은 교환 목록 갱신
       queryClient.invalidateQueries({
         queryKey: ['exchanges', { shopId }],
       });
+      // 교환 제시한 상대방에게 알림 전송
+      sendNotification({
+        notificationCase: 'refuseExchange',
+        userId: proposerId,
+        grade,
+        name,
+      });
     },
+  });
+
+  const { mutate: sendNotification } = useMutation({
+    mutationFn: (dto) => notificationsApi.sendNotification(dto),
   });
 
   const { mutate: approveExchange } = useMutation({
@@ -53,6 +70,13 @@ function CardBottom({ card, intent, isProposedByMe = false }) {
       // shop의 내가 제안받은 교환 목록 갱신 - 승인 시
       queryClient.invalidateQueries({
         queryKey: ['exchanges', { shopId }],
+      });
+      // 교환 제시한 상대방에게 알림 전송
+      sendNotification({
+        notificationCase: 'approveExchange',
+        userId: proposerId,
+        grade,
+        name,
       });
     },
   });
@@ -87,6 +111,10 @@ function CardBottom({ card, intent, isProposedByMe = false }) {
     cancelProposeExchange();
   };
 
+  const handleClickModalRefuseExchange = () => {
+    refuseProposeExchange();
+  };
+
   const handleClickExchangeRefuse = () => {
     if (!isLoggedIn)
       return modal.open(
@@ -105,7 +133,7 @@ function CardBottom({ card, intent, isProposedByMe = false }) {
         content={`[${grade} | ${name}]
          카드와의 교환을 거절하시겠습니까?`}
         buttonText="거절하기"
-        onClick={handleClickModalCancelExchange}
+        onClick={handleClickModalRefuseExchange}
       />
     );
   };

--- a/components/molecules/CardDetailBottom.jsx
+++ b/components/molecules/CardDetailBottom.jsx
@@ -1,5 +1,6 @@
 'use client';
 
+import notificationsApi from '@/api/notifications/notifications.api';
 import shopsApi from '@/api/shops/shops.api';
 import exchangeIcon from '@/assets/images/ic-exchange.png';
 import { useAuth } from '@/contexts/AuthContext';
@@ -8,15 +9,15 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import { useController, useForm } from 'react-hook-form';
+import { useController } from 'react-hook-form';
 import Button from '../atoms/Button';
 import Divider from '../atoms/Divider';
 import GradeCardBadge from '../atoms/GradeCardBadge';
 import NumberStepper from '../atoms/NumberStepper';
-import ConfirmModal from './ConfirmModal';
-import CardDetailModalForSale from '../templates/CardDetailModalForSale';
 import Modal from '../organisms/Modal';
 import CardActionModal from '../templates/CardActionModal';
+import CardDetailModalForSale from '../templates/CardDetailModalForSale';
+import ConfirmModal from './ConfirmModal';
 
 function CardDetailBottom({
   cardDetail,
@@ -72,6 +73,8 @@ function CardDetailBottom({
     reserveCount,
     exchangeDesc,
     availableQuantity,
+    sellerId,
+    id,
   } = cardDetail;
 
   useEffect(() => {
@@ -86,17 +89,46 @@ function CardDetailBottom({
 
   const { mutate: purchaseCards } = useMutation({
     mutationFn: (dto) => shopsApi.purchaseCards(dataId, dto),
-    onSuccess: () => {
+    onSuccess: async (data) => {
       router.push(
         `/result?intent=purchase&&isSuccess=true&&grade=${grade}&&name=${name}&&count=${count}`
       );
       queryClient.invalidateQueries({ queryKey: ['me'] });
+      // 나에게 구매 성공 알림 발송
+      sendNotification({
+        notificationCase: 'purchaseCard',
+        grade,
+        name,
+        purchaseCount: count,
+      });
+      // 상점의 판매자에게 판매 알림 발송
+      sendNotification({
+        notificationCase: 'soldMyCard',
+        userId: sellerId,
+        shopId: id,
+        grade,
+        name,
+        purchaseCount: count,
+      });
+      // 판매로 인해 매진이 됐을 경우 판매자에게 매진 알림도 발송
+      if (!data.isSoldOut) return;
+      sendNotification({
+        notificationCase: 'soldOut',
+        userId: sellerId,
+        shopId: id,
+        grade,
+        name,
+      });
     },
     onError: () => {
       router.push(
         `/result?intent=purchase&&isSuccess=false&&grade=${grade}&&name=${name}&&count=${count}`
       );
     },
+  });
+
+  const { mutate: sendNotification } = useMutation({
+    mutationFn: (dto) => notificationsApi.sendNotification(dto),
   });
 
   const { mutate: deleteShop } = useMutation({
@@ -113,7 +145,7 @@ function CardDetailBottom({
       );
     },
   });
-
+  console.log(cardDetail);
   const handleClickModalPurchase = () => {
     const data = {
       price,

--- a/components/templates/CardDetailModalForExchange.jsx
+++ b/components/templates/CardDetailModalForExchange.jsx
@@ -1,12 +1,13 @@
+import notificationsApi from '@/api/notifications/notifications.api';
 import shopsApi from '@/api/shops/shops.api';
 import { useModal } from '@/contexts/ModalContext';
 import { useMutation } from '@tanstack/react-query';
 import { usePathname, useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
-import Card from '../organisms/Card';
-import Title from '../molecules/Title';
-import InputTextBox from '../molecules/InputTextBox';
 import Button from '../atoms/Button';
+import InputTextBox from '../molecules/InputTextBox';
+import Title from '../molecules/Title';
+import Card from '../organisms/Card';
 
 function CardDetailModalForExchange({ card, onBack }) {
   const { id, imgUrl, name, grade, genre, nickname, reserveCount, price } =
@@ -29,7 +30,19 @@ function CardDetailModalForExchange({ card, onBack }) {
       router.push(
         `/result?intent=proposeExchange&&isSuccess=true&&grade=${grade}&&name=${name}&&count=${data.salesCount}`
       );
+      // 상점의 판매자에게 알림 전송
+      sendNotification({
+        notificationCase: 'arriveProposal',
+        userId: sellerId,
+        shopId: id,
+        grade,
+        name,
+      });
     },
+  });
+
+  const { mutate: sendNotification } = useMutation({
+    mutationFn: (dto) => notificationsApi.sendNotification(dto),
   });
 
   const handleExchangeClick = (dto) => {


### PR DESCRIPTION
#90 

- /api/notifications/notifications.api.js 
  - sendNotification, getNotificationsOfMe 추가
- shops.api.js에 refuseProposeExchange 추가
   - 교환 거절의 경우 '취소'와 완전히 동일하여 같은 API를 사용하고 있었으나 '취소'의 경우에는 알림 전송이 필요없으므로 API를 분리
- 알림 전송이 필요한 함수들에 관련 코드 추가
   - refuseExchange, approveExchange, purchaseCards, proposeExchange